### PR TITLE
Ajustar conteúdo do Select

### DIFF
--- a/app/src/screens/Home/Home.tsx
+++ b/app/src/screens/Home/Home.tsx
@@ -240,6 +240,12 @@ const StyledConnectLink = styled.a`
 
 const StyledSelect = styled(Select)`
   width: 80%;
+
+  ul li {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
 `;
 
 const StyledLoading = styled.span`


### PR DESCRIPTION
**Tarefas:**

- [x] Ajustar conteúdo do `Select`para não ultrapassar a largura do elemento.

Resolve #1

## Prévia

### Antes 
![image](https://user-images.githubusercontent.com/28319535/78459589-7778e000-7690-11ea-8436-7798cd0296d0.png)

### Depois
![image](https://user-images.githubusercontent.com/28319535/78459594-7d6ec100-7690-11ea-9a11-9170acca002c.png)


