### PR TITLE
Fix: Converter uma playlist sem selecioná-la manualmente

### DIFF
--- a/app/src/screens/Home/Home.tsx
+++ b/app/src/screens/Home/Home.tsx
@@ -23,7 +23,7 @@ const Home = () => {
   const [currentPlaylist, setCurrentPlaylist] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { showAlert } = useContext(ModalContext);
-
+  
   const {
     youtubeToken,
     spotifyToken,
@@ -71,7 +71,7 @@ const Home = () => {
     }
 
     if (!currentPlaylist) {
-      showAlert("Please, select a origni playlist to be converted.");
+      showAlert("Please, select a origin playlist to be converted.");
       return;
     }
 

--- a/app/src/screens/Home/Home.tsx
+++ b/app/src/screens/Home/Home.tsx
@@ -41,7 +41,7 @@ const Home = () => {
     ) {
       setCurrentPlaylist(playlists.items[0].value);
     }
-  }, [playlists]);
+  }, [playlists, currentPlaylist]);
   
   const onPlaylistDestinationChange = (e: ChangeEvent<HTMLInputElement>) => {
     setPlaylistDestination(e.target.value);

--- a/app/src/screens/Home/Home.tsx
+++ b/app/src/screens/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState, useContext } from "react";
+import React, { ChangeEvent, useState, useContext, useEffect } from "react";
 import styled from "styled-components";
 import {
   Window,
@@ -33,6 +33,16 @@ const Home = () => {
     playlists
   } = usePlatform();
 
+  useEffect(() => {
+    if (
+      !currentPlaylist &&
+      playlists?.items?.length &&
+      playlists.items[0]?.value
+    ) {
+      setCurrentPlaylist(playlists.items[0].value);
+    }
+  }, [playlists]);
+  
   const onPlaylistDestinationChange = (e: ChangeEvent<HTMLInputElement>) => {
     setPlaylistDestination(e.target.value);
   };
@@ -89,6 +99,7 @@ const Home = () => {
         data: { url }
       } = await api.get("/convert-playlist", { params });
 
+      console.log(url);
       showAlert(
         <div style={{ textAlign: "center" }}>
           Playlist successfully converted :)

--- a/app/src/screens/Home/Home.tsx
+++ b/app/src/screens/Home/Home.tsx
@@ -23,7 +23,7 @@ const Home = () => {
   const [currentPlaylist, setCurrentPlaylist] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { showAlert } = useContext(ModalContext);
-  
+
   const {
     youtubeToken,
     spotifyToken,
@@ -42,7 +42,7 @@ const Home = () => {
       setCurrentPlaylist(playlists.items[0].value);
     }
   }, [playlists, currentPlaylist]);
-  
+
   const onPlaylistDestinationChange = (e: ChangeEvent<HTMLInputElement>) => {
     setPlaylistDestination(e.target.value);
   };
@@ -99,7 +99,6 @@ const Home = () => {
         data: { url }
       } = await api.get("/convert-playlist", { params });
 
-      console.log(url);
       showAlert(
         <div style={{ textAlign: "center" }}>
           Playlist successfully converted :)
@@ -148,11 +147,11 @@ const Home = () => {
                 (playlists.loading ? (
                   <StyledLoading>Loading...</StyledLoading>
                 ) : (
-                  <StyledSelect
-                    items={playlists.items}
-                    onChange={onCurrentPlaylistChange}
-                  />
-                ))}
+                    <StyledSelect
+                      items={playlists.items}
+                      onChange={onCurrentPlaylistChange}
+                    />
+                  ))}
             </PlatformBox>
             <StyledChangeOrderContainer>
               <Button onClick={onTogglePress}>
@@ -172,13 +171,13 @@ const Home = () => {
                   <StyledConnectLink href={to.href}>Connect</StyledConnectLink>
                 </Button>
               ) : (
-                <TextField
-                  placeholder="Your playlist name"
-                  width="80%"
-                  onChange={onPlaylistDestinationChange}
-                  value={playlistDestination}
-                />
-              )}
+                  <TextField
+                    placeholder="Your playlist name"
+                    width="80%"
+                    onChange={onPlaylistDestinationChange}
+                    value={playlistDestination}
+                  />
+                )}
             </PlatformBox>
           </StyledHeader>
           <StyledFooter>
@@ -191,8 +190,8 @@ const Home = () => {
               {isLoading ? (
                 <StyledLoader src={spinnerIcon} alt="Loading spinner" />
               ) : (
-                <span>Convert</span>
-              )}
+                  <span>Convert</span>
+                )}
             </Button>
           </StyledFooter>
         </WindowContent>


### PR DESCRIPTION
Correção de problema descrito na issue #2:
- Correção de escrita _(origni > origin)_
- Definir uma `currentPlaylist` por padrão sem precisar interagir com o _select_.

Closes #2 